### PR TITLE
Change cmake files to ease compiling and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
   - cmake --version
   - ls -la
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install gcc48; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install valgrind; fi
 install:
   # /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,11 @@ project(algo CXX)
 #compiler option with accordance to compiler
 SET (CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS}")
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	SET (CMAKE_CXX_FLAGS "-std=c++11 -O3 -Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
+	#boost has lot of warning of unused-parameter
+	SET (CMAKE_CXX_FLAGS "-std=c++11 -O3 -Wall -Wextra -Werror -Wno-unused-parameter ${CMAKE_CXX_FLAGS}")
 ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	SET (CMAKE_CXX_FLAGS "-std=c++11 -O3 -Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
+	#boost has lot of warning of unused-parameter
+	SET (CMAKE_CXX_FLAGS "-std=c++11 -O3 -Wall -Wextra -Werror -Wno-unused-parameter ${CMAKE_CXX_FLAGS}")
 ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	IF (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
 		MESSAGE ( FATAL_ERROR "MSVC doesn't support C++11.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ project(algo CXX)
 #compiler option with accordance to compiler
 SET (CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS}")
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	SET (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+	SET (CMAKE_CXX_FLAGS "-std=c++11 -O3 -Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
 ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-	SET (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+	SET (CMAKE_CXX_FLAGS "-std=c++11 -O3 -Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
 ELSEIF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	IF (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19)
 		MESSAGE ( FATAL_ERROR "MSVC doesn't support C++11.")
@@ -91,4 +91,9 @@ target_link_libraries(util_test util)
 target_link_libraries(util_test gmock)
 target_link_libraries(util_test gtest)
 add_test(util_test util_test)
+
+#valgrind
+set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --error-exitcode=1")
+find_program(CTEST_MEMORYCHECK_COMMAND NAMES valgrind)
+include(Dart)
 

--- a/algo/ad_test/TestUtil.cpp
+++ b/algo/ad_test/TestUtil.cpp
@@ -68,8 +68,12 @@ namespace algo { namespace ad_test {
         ublas::matrix<double> result(valueSize, derivativeSize);
 
         for (std::size_t ri = 0; ri < valueSize; ++ri) {
-            ublas::row(result, ri) 
-                = vectorDualVectorDerivative(ri).getDerivative();
+			const ublas::vector<double>& derivative
+				= vectorDualVectorDerivative(ri).getDerivative();
+   			std::copy(
+				derivative.begin(),
+				derivative.end(),
+				ublas::row(result, ri).begin());
         }
 
         return result;

--- a/algo/nm/GaussNewton.cpp
+++ b/algo/nm/GaussNewton.cpp
@@ -37,6 +37,9 @@ namespace algo { namespace nm {
                 = ublas::prod(ublas::trans(jacobianMatrix), jacobianMatrix);
             const bool isSuccess 
                 = util::invert(tempMatrix, inverseMatrix);
+            if (!isSuccess) {
+                //TODO
+            }
             const ublas::vector<double> tempVector1 
                 = ublas::prod(ublas::trans(jacobianMatrix), residual);
             const ublas::vector<double> tempVector2

--- a/ci/build_cmake.sh
+++ b/ci/build_cmake.sh
@@ -40,5 +40,21 @@ then
 	exit $ret
 fi
 
+ctest -T memcheck --verbose | tee memcheck.log
+cat Testing/Temporary/MemoryChecker.*.log
+
+ret=${PIPESTATUS[0]}
+if [ $ret -ne 0 ]
+then
+	exit $ret
+fi
+cat memcheck.log | grep "Memory Leak" > /dev/null
+ret=$?
+if [ $ret -eq 0 ]
+then
+	exit 1
+fi
+
 exit 0
+
 

--- a/ci/build_cmake.sh
+++ b/ci/build_cmake.sh
@@ -41,7 +41,10 @@ then
 fi
 
 ctest -T memcheck --verbose | tee memcheck.log
-cat Testing/Temporary/MemoryChecker.*.log
+if [ -f Testing/Temporary/MemoryChecker.*.log ]
+then
+	cat Testing/Temporary/MemoryChecker.*.log
+fi
 
 ret=${PIPESTATUS[0]}
 if [ $ret -ne 0 ]

--- a/ci/build_cmake.sh
+++ b/ci/build_cmake.sh
@@ -41,10 +41,6 @@ then
 fi
 
 ctest -T memcheck --verbose | tee memcheck.log
-if [ -f Testing/Temporary/MemoryChecker.*.log ]
-then
-	cat Testing/Temporary/MemoryChecker.*.log
-fi
 
 ret=${PIPESTATUS[0]}
 if [ $ret -ne 0 ]


### PR DESCRIPTION
Issue #62.
- Add compiler option
  - `-Wall -Wextra -Werror`
  - boost has a lot of error caused by `unused-parameter` so that we ignore this warning
- Add memory leak test with valgrind
